### PR TITLE
fix: do not fail on `apt-get update`

### DIFF
--- a/web-build/pre.Dockerfile.sqlsrv
+++ b/web-build/pre.Dockerfile.sqlsrv
@@ -2,13 +2,13 @@
 ARG odbc_version=2.3.7
 
 ENV PATH="${PATH}:/opt/mssql-tools/bin"
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests apt-utils curl gnupg2 ca-certificates
+RUN (apt-get update || true) && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests apt-utils curl gnupg2 ca-certificates
 
 RUN curl -sSL -O https://packages.microsoft.com/keys/microsoft.asc
 RUN apt-key add <microsoft.asc
 RUN curl -sSL -o /etc/apt/sources.list.d/mssql-release.list https://packages.microsoft.com/config/debian/11/prod.list
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests \
+RUN (apt-get update || true) && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests \
     build-essential \
     dialog \
     php-pear \


### PR DESCRIPTION
## The Issue

- https://github.com/ddev/ddev/pull/5623

We must not allow apt-get update to fail if some repository is down, because it can stop the webserver from starting.

## How This PR Solves The Issue

Allows `apt-get install` to continue after a fail for `apt-get update`.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

