### PR TITLE
#29 automated tests are failing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
         ddev_version: [stable, HEAD]
       fail-fast: false
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: ddev/github-action-add-on-test@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,6 +34,10 @@ jobs:
         ddev_version: [stable, HEAD]
       fail-fast: false
 
+    # We need to use the ubuntu-20.04 image because the sqlsrv service uses the
+    # mcr.microsoft.com/mssql/server:2019-CU12-ubuntu-20.04 image.
+    # See the issue https://github.com/ddev/ddev-sqlsrv/issues/29 for more
+    # details.
     runs-on: ubuntu-20.04
 
     steps:

--- a/docker-compose.sqlsrv.yaml
+++ b/docker-compose.sqlsrv.yaml
@@ -4,8 +4,8 @@ services:
     container_name: ddev-${DDEV_SITENAME}-sqlsrv
     hostname: ddev-${DDEV_SITENAME}-sqlsrv
 
-    # For possible options: https://hub.docker.com/_/microsoft-mssql-server.
-    # This does not yet work with Apple M1. For more details:
+    # For available options look at https://hub.docker.com/_/microsoft-mssql-server.
+    # This image that does not work with Apple M1 yet. For more details:
     # - https://github.com/microsoft/mssql-docker/issues/734
     # - https://github.com/microsoft/mssql-docker/issues/802
     image: mcr.microsoft.com/mssql/server:2019-CU12-ubuntu-20.04

--- a/docker-compose.sqlsrv.yaml
+++ b/docker-compose.sqlsrv.yaml
@@ -5,7 +5,9 @@ services:
     hostname: ddev-${DDEV_SITENAME}-sqlsrv
 
     # For possible options: https://hub.docker.com/_/microsoft-mssql-server.
-    # This does not yet work with Apple M1. See: https://github.com/microsoft/mssql-docker/issues/734
+    # This does not yet work with Apple M1. For more details:
+    # - https://github.com/microsoft/mssql-docker/issues/734
+    # - https://github.com/microsoft/mssql-docker/issues/802
     image: mcr.microsoft.com/mssql/server:2019-CU12-ubuntu-20.04
 
     user: root


### PR DESCRIPTION
## The Issue
The tests fail in GitHub Action runner.

## How This PR Solves The Issue
Use the ubuntu-20.04 image in the runner that has the same Ubuntu version of the MSSql server:2019-CU12-ubuntu-20.04 image.

