### PR TITLE
docs: update `ddev get` to `ddev add-on get` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,21 @@ Some workarounds are described in the following threads:
 
 **Due to lack of upstream support, this add-on can only be used with amd64 machines, and is not usable on arm64 machines like Apple Silicon computers.**
 
+For DDEV v1.23.5 or above run
+
+```bash
+ddev add-on get ddev/ddev-sqlsrv
+```
+
+For earlier versions of DDEV run
+
 ```bash
 ddev get ddev/ddev-sqlsrv
+```
+
+Then restart your project
+
+```bash
 ddev restart
 ```
 


### PR DESCRIPTION
In [DDEV 1.23.5](https://github.com/ddev/ddev/releases/tag/v1.23.5) the ddev get command was deprecated in favour of ddev add-on get.

This PR updates those references in the readme file. There may be some additional markdown improvements as well.

The changes were made manually, but the PR itself was automatically created - I'm doing over 100 of these. I apologise if its not 100% to the contributor standards required by this repo. Let me know if I need to change anything.