### PR TITLE
Allow to install on Apple Silicon with Rosetta enabled

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -12,9 +12,21 @@ pre_install_actions:
   # https://github.com/microsoft/mssql-docker/issues/734#issuecomment-1382358649
   #ddev-nodisplay
   #ddev-description:Check architecture type for incompatible arm64 type
-  if [ "$(arch)" = "arm64" -o "$(arch)" = "aarch64" ]; then
-    echo "This package does not work on arm64 machines";
-    exit 1;
+  # If cpu is Apple branded, use arch binary to check if x86_64 code can run
+  if [[ "$(sysctl -n machdep.cpu.brand_string)" == *'Apple'* ]]; then
+    if arch -x86_64 /usr/bin/true 2> /dev/null; then
+      echo "To make this package work on arm64 machines, Rosetta is used.";
+    else
+      echo "This package does not work on arm64 machines, unless Rosetta is enabled.";
+      echo "If needed, run /usr/sbin/softwareupdate –install-rosetta –agree-to-license";
+      echo "Make sure Rosetta is enabled in your Docker provider.";
+      exit 1;
+    fi
+  else
+    if [ "$(arch)" = "arm64" -o "$(arch)" = "aarch64" ]; then
+      echo "This package does not work on arm64 machines";
+      exit 1;
+    fi
   fi
 - |
   # If there was an existing .ddev/web-build/Dockerfile.sqlsrv we need to remove it


### PR DESCRIPTION
## The Issue

Even with Rosetta being enabled on Apple Silicon, the add-on cannot be installed.

## How This PR Solves The Issue

If on Apple Silicon with Rosetta, install add-on. If not having Rosetta or if on another ARM system, refuse to install.

## Manual Testing Instructions

Running `ddev add-on get https://github.com/kdambekalns/ddev-sqlsrv/tarball/task/support-apple-silicon`

- on Apple Silicon with Rosetta should show `To make this package work on arm64 machines, Rosetta is used.` and install the add-on
- on Apple Silicon without Rosetta should show `This package does not work on arm64 machines, unless Rosetta is enabled.`, show a hint on how to install that and not install the add-on
- on any other ARM CPU should show `This package does not work on arm64 machines` and not install the add-on
- on a non-ARM CPU should install the add-on

## Related Issue Link(s)

Fixes #33

