### PR TITLE
Fix versions in pre.Dockerfile.sqlsrv

### DIFF
--- a/web-build/pre.Dockerfile.sqlsrv
+++ b/web-build/pre.Dockerfile.sqlsrv
@@ -1,5 +1,5 @@
 #ddev-generated
-ARG odbc_version=2.3.7
+ARG odbc_version=2.3.11
 
 ENV PATH="${PATH}:/opt/mssql-tools/bin"
 RUN (apt-get update || true) && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests apt-utils curl gnupg2 ca-certificates
@@ -19,7 +19,7 @@ RUN (apt-get update || true) && DEBIAN_FRONTEND=noninteractive apt-get install -
     unixodbc-dev=$odbc_version \
     locales
 
-RUN ACCEPT_EULA=Y DEBIAN_FRONTEND=noninteractive apt-get install -y msodbcsql18 mssql-tools
+RUN ACCEPT_EULA=Y DEBIAN_FRONTEND=noninteractive apt-get install -y msodbcsql18 mssql-tools18
 
 # Change the PHP version to what you want. It is currently set to version 8.0.
 RUN pecl channel-update pecl.php.net


### PR DESCRIPTION
## The Issue

See https://github.com/ddev/ddev-sqlsrv/issues/35

## How This PR Solves The Issue

It adjusts the `odbc_version` to 2.3.11 and installs `mssql-tools18` instead of `mssql-tools`.

## Manual Testing Instructions

Doing

1. `ddev config` with all default values
2. `ddev add-on get ddev/ddev-sqlsrv`
3. `ddev start`

should fail without those adjustments, see #35. With the adjustment, it builds and start fine.

## Related Issue Link(s)

Fixes https://github.com/ddev/ddev-sqlsrv/issues/35
